### PR TITLE
fix(api): Register new user with username start and end with space.

### DIFF
--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -215,8 +215,7 @@ class MemberListAPITest(APITestCase):
             'password': 'azerty'
         }
         response = self.client.post(reverse('api-member-list'), data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIsNotNone(response.data.get('username'))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_register_new_user_without_email(self):
         """


### PR DESCRIPTION
Après mes recherches, DRF applique un strip sur les valeurs des tableaux envoyés à DRF. Il n'est donc plus possible de rencontrer l'erreur soulevé par le test qui échoue.
