### PR TITLE
Une requête vers matomo pour les gouverner tous

### DIFF
--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import urllib.parse
 from datetime import timedelta, datetime, date
@@ -58,76 +59,46 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
                     urls.append(NamedUrl(subchild.title, subchild.get_absolute_url_online(), 2))
         return urls
 
-    def get_all_refs(self, urls, start, end, method):
+    def get_all_statistics(self, urls, start, end, methods):
         date_ranges = "{},{}".format(start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
-        data_request = {"module": "API", "method": "API.getBulkRequest", "format": "json"}
+        data_request = {"module": "API", "method": "API.getBulkRequest", "format": "json", "filter_limit": -1}
+        data_structured = {}
 
-        for index, url in enumerate(urls):
+        for method in methods:
+            data_structured[method] = []
+
+        for index, method_url in enumerate(itertools.product(methods, urls)):
+            method = method_url[0]
+            url = method_url[1]
             absolute_url = f"{self.request.scheme}://{self.request.get_host()}{url.url}"
             param_url = f"pageUrl=={urllib.parse.quote_plus(absolute_url)}"
 
-            data_request.update(
-                {
-                    f"urls[{index}]": urllib.parse.urlencode(
-                        {
-                            "method": method,
-                            "idSite": self.matomo_site_id,
-                            "date": date_ranges,
-                            "period": "day",
-                            "segment": ",".join([param_url]),
-                        }
-                    )
-                }
-            )
+            request_params = {"method": method, "idSite": self.matomo_site_id, "date": date_ranges, "period": "day"}
+            if method.startswith("Referrers"):  # referrers requests use segment for define url
+                request_params["segment"] = ",".join([param_url])
+            elif method == "Actions.getPageUrl":
+                request_params["pageUrl"] = absolute_url
+
+            data_request.update({f"urls[{index}]": urllib.parse.urlencode(request_params)})
 
         try:
             response_matomo = requests.post(url=self.matomo_api_url, data=data_request)
             data = response_matomo.json()
             if type(data) == dict and data.get("result", "") == "error":
                 data = {}
-                self.logger.error(data.get("message", "Something failed with Matomo reporting system"))
-                messages.error(self.request, data.get("message", _(f"Impossible de récupérer les référents du site.")))
-
-        except Exception:
-            data = {}
-            self.logger.exception(f"Something failed with Matomo reporting system")
-            messages.error(self.request, _(f"Impossible de récupérer les référents du site."))
-
-        return data
-
-    def get_all_stats(self, urls, start, end):
-        date_ranges = "{},{}".format(start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
-        data_request = {"module": "API", "method": "API.getBulkRequest", "format": "json"}
-
-        for index, url in enumerate(urls):
-            absolute_url = f"{self.request.scheme}://{self.request.get_host()}{url.url}"
-
-            data_request.update(
-                {
-                    f"urls[{index}]": urllib.parse.urlencode(
-                        {
-                            "method": "Actions.getPageUrl",
-                            "idSite": self.matomo_site_id,
-                            "date": date_ranges,
-                            "period": "day",
-                            "pageUrl": absolute_url,
-                        }
-                    )
-                }
-            )
-
-        try:
-            response_matomo = requests.post(url=self.matomo_api_url, data=data_request)
-            data = response_matomo.json()
-            if type(data) == dict and data.get("result", "") == "error":
-                data = {}
-                self.logger.error(data.get("message", "Something failed with Matomo reporting system"))
+                self.logger.error(data.get("message", "Something failed with Matomo reporting system."))
                 messages.error(
                     self.request, data.get("message", _(f"Impossible de récupérer les statistiques du site."))
                 )
+
+            for index, method_url in enumerate(itertools.product(methods, urls)):
+                method = method_url[0]
+                data_structured[method].append(data[index])
+
+            return data_structured
         except Exception:
             data = {}
-            self.logger.exception(f"Something failed with Matomo reporting system")
+            self.logger.exception(f"Something failed with Matomo reporting system.")
             messages.error(self.request, _(f"Impossible de récupérer les statistiques du site."))
 
         return data
@@ -245,10 +216,17 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
 
         # Each function sends only one bulk request for all the urls
         # Each variable is a list of dictionnaries (one for each url)
-        all_stats = self.get_all_stats(urls, start_date, end_date)
-        all_referrers = self.get_all_refs(urls, start_date, end_date, "Referrers.getWebsites")
-        all_type_referrers = self.get_all_refs(urls, start_date, end_date, "Referrers.getReferrerType")
-        all_keywords = self.get_all_refs(urls, start_date, end_date, "Referrers.getKeywords")
+        all = self.get_all_statistics(
+            urls,
+            start_date,
+            end_date,
+            ["Referrers.getReferrerType", "Referrers.getWebsites", "Referrers.getKeywords", "Actions.getPageUrl"],
+        )
+
+        all_stats = all["Actions.getPageUrl"]
+        all_ref_websites = all["Referrers.getWebsites"]
+        all_ref_types = all["Referrers.getReferrerType"]
+        all_ref_keyword = all["Referrers.getKeywords"]
 
         for index, url in enumerate(urls):
             cumul_stats = self.get_cumulative(all_stats[index])
@@ -264,9 +242,9 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
                 else:
                     cumulative_stats[url][item] = cumul_stats.get(item, 0)
 
-            referrers = self.merge_ref_to_data(referrers, self.get_ref_metrics(all_referrers[index]))
-            type_referrers = self.merge_ref_to_data(type_referrers, self.get_ref_metrics(all_type_referrers[index]))
-            keywords = self.merge_ref_to_data(keywords, self.get_ref_metrics(all_keywords[index]))
+            referrers = self.merge_ref_to_data(referrers, self.get_ref_metrics(all_ref_websites[index]))
+            type_referrers = self.merge_ref_to_data(type_referrers, self.get_ref_metrics(all_ref_types[index]))
+            keywords = self.merge_ref_to_data(keywords, self.get_ref_metrics(all_ref_keyword[index]))
 
         if display_mode.lower() == "global":
             reports = {NamedUrl(display_mode, "", 0): self.merge_report_to_global(reports, report_field)}


### PR DESCRIPTION
Avec ce commit, on passe de 4 requêtes matomo pour les contenus, à une seule requêtes. Même si le chargement reste long pour les gros tutos (là c'est clairement matomo qui traine à répondre sur les grosses requêtes), je trouve qu'il vaut mieux déleguer à matomo la tache de gérer de manière optimale les requêtes bulk, plutôt que de bidouiller des choses chez nous à base de thread.

J'en ai profiter pour mettre à jour le mock de l'API qui permet de faire passer les tests. Maintenant que les requêtes sont lancées en bulk, le résultats censé être renvoyé n'est plus le même.